### PR TITLE
(#1, #2) Upgraded to A16!!

### DIFF
--- a/ED-Stargate/About/About.xml
+++ b/ED-Stargate/About/About.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
 	<name>ED-Stargate</name>
-	<targetVersion>0.14.1249</targetVersion>
-	<author>Jaxxa</author>
+	<targetVersion>0.15.1284</targetVersion>
+	<author>Jaxxa + HopeSeekr</author>
 	<url>https://ludeon.com/forums/index.php?topic=18995.0</url>
-	<description>Version: 02.00.02
+	<description>Version: 02.00.03
 Discussion, Non Steam Downloads and GitHub Repositories of this mod is available at: https://ludeon.com/forums/index.php?topic=18995
 Please Use that Thread for Discussion / Feedback that would like me to reply to. 
 Ideally Bugs should be logged on GitHub although in the discussion thread is also fine.
 
-WARNING: This mod uses the Rimworld Base Save Functionality in ways that it was never designed to support, mainly saving specific things into a separate file instead of saving everything on the map to one file at once. Because of this there may be adverse effects. The main one that I have found is that after traveling through the Stargate Social opinions relating to that colonist will be lost, they will effectively be meeting everyone for the first time again. At this time I do not know of a practical way to resolve this issue.
-
 The Stargate system allows you to transport materials over the great distances between colonies.
 ED-Autoloader is supported to more easily load resources.
+
+WARNING: This mod uses the Rimworld Base Save Functionality in ways that it was never designed to support, mainly saving specific things into a separate file instead of saving everything on the map to one file at once. Because of this there may be adverse effects. The main one that I have found is that after traveling through the Stargate Social opinions relating to that colonist will be lost, they will effectively be meeting everyone for the first time again. At this time I do not know of a practical way to resolve this issue.
 	</description>
 </ModMetaData>

--- a/ED-Stargate/About/About.xml
+++ b/ED-Stargate/About/About.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
 	<name>ED-Stargate</name>
-	<targetVersion>0.15.1284</targetVersion>
+	<targetVersion>0.16.1393</targetVersion>
 	<author>Jaxxa + HopeSeekr</author>
 	<url>https://ludeon.com/forums/index.php?topic=18995.0</url>
 	<description>Version: 02.00.03

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ ED-Autoloader is supported to more easily load resources.
 02.00.03
 * Alpha 15 Update (only had to change the supported version number)
 
+02.00.04
+* Alpha 16 Update (lots of small compatibility changes, esp regarding multiple maps).

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ ED-Autoloader is supported to more easily load resources.
 
 02.00.02
 * Building against 1249
+
+02.00.03
+* Alpha 15 Update (only had to change the supported version number)
+

--- a/Source/ED-Stargate/ED-Stargate.csproj
+++ b/Source/ED-Stargate/ED-Stargate.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.14.6054.28678, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\lib\A14.1249\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\Assembly-CSharp.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -43,7 +43,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\lib\A14.1249\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/ED-Stargate/Properties/AssemblyInfo.cs
+++ b/Source/ED-Stargate/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/ED-Stargate/Stargate/Building_OffWorldStargate.cs
+++ b/Source/ED-Stargate/Stargate/Building_OffWorldStargate.cs
@@ -28,9 +28,9 @@ namespace Enhanced_Development.Stargate
 
         #region Override
 
-        public override void SpawnSetup()
+        public override void SpawnSetup(Map map)
         {
-            base.SpawnSetup();
+            base.SpawnSetup(map);
 
         }
 
@@ -120,9 +120,9 @@ namespace Enhanced_Development.Stargate
                 Messages.Message("Ok Fine.", MessageSound.SeriousAlert);
 
                 this.Destroy(DestroyMode.Vanish);
-                GenSpawn.Spawn(ThingDef.Named("Stargate"), this.Position);
+                GenSpawn.Spawn(ThingDef.Named("Stargate"), this.Position, this.Map);
 
-                foreach (Pawn currentPawn in Find.MapPawns.FreeColonistsAndPrisoners.ToList())
+                foreach (Pawn currentPawn in Find.VisibleMap.mapPawns.FreeColonistsAndPrisoners.ToList())
                 {
                     currentPawn.Destroy(DestroyMode.Vanish);
                 }

--- a/Source/ED-Stargate/Stargate/Building_OffWorldStargate.cs
+++ b/Source/ED-Stargate/Stargate/Building_OffWorldStargate.cs
@@ -19,6 +19,8 @@ namespace Enhanced_Development.Stargate
 
         public int warned = 0;
 
+        private Map currentMap;
+
         #endregion
 
         static Building_OffWorldStargate()
@@ -30,8 +32,8 @@ namespace Enhanced_Development.Stargate
 
         public override void SpawnSetup(Map map)
         {
+            this.currentMap = map;
             base.SpawnSetup(map);
-
         }
 
         //Saving game
@@ -120,7 +122,7 @@ namespace Enhanced_Development.Stargate
                 Messages.Message("Ok Fine.", MessageSound.SeriousAlert);
 
                 this.Destroy(DestroyMode.Vanish);
-                GenSpawn.Spawn(ThingDef.Named("Stargate"), this.Position, this.Map);
+                GenSpawn.Spawn(ThingDef.Named("Stargate"), this.Position, this.currentMap);
 
                 foreach (Pawn currentPawn in Find.VisibleMap.mapPawns.FreeColonistsAndPrisoners.ToList())
                 {

--- a/Source/ED-Stargate/Stargate/Building_Stargate.cs
+++ b/Source/ED-Stargate/Stargate/Building_Stargate.cs
@@ -48,6 +48,8 @@ namespace Enhanced_Development.Stargate
         int requiredCapacitorCharge = 1000;
         int chargeSpeed = 1;
 
+        private Map currentMap;
+
         #endregion
 
         static Building_Stargate()
@@ -85,6 +87,7 @@ namespace Enhanced_Development.Stargate
 
         public override void SpawnSetup(Map map)
         {
+            this.currentMap = map;
             base.SpawnSetup(map);
 
             this.power = base.GetComp<CompPowerTrader>();
@@ -397,7 +400,7 @@ namespace Enhanced_Development.Stargate
             {
 
                 //Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsInAutoLoader(this);
-                Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsNearBuilding(this, Building_Stargate.ADDITION_DISTANCE, this.Map);
+                Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsNearBuilding(this, Building_Stargate.ADDITION_DISTANCE, this.currentMap);
 
                 if (foundThing != null)
                 {
@@ -508,7 +511,7 @@ namespace Enhanced_Development.Stargate
 
                     currentThing.SetFactionDirect(RimWorld.Faction.OfPlayer);
 
-                    GenPlace.TryPlaceThing(currentThing, this.Position + new IntVec3(0, 0, -2), this.Map, ThingPlaceMode.Near);
+                    GenPlace.TryPlaceThing(currentThing, this.Position + new IntVec3(0, 0, -2), this.currentMap, ThingPlaceMode.Near);
                 }
                 //Log.Message("End of Placing");
                 inboundBuffer.Clear();

--- a/Source/ED-Stargate/Stargate/Building_Stargate.cs
+++ b/Source/ED-Stargate/Stargate/Building_Stargate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -83,9 +83,9 @@ namespace Enhanced_Development.Stargate
 
         #region Override
 
-        public override void SpawnSetup()
+        public override void SpawnSetup(Map map)
         {
-            base.SpawnSetup();
+            base.SpawnSetup(map);
 
             this.power = base.GetComp<CompPowerTrader>();
 
@@ -397,7 +397,7 @@ namespace Enhanced_Development.Stargate
             {
 
                 //Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsInAutoLoader(this);
-                Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsNearBuilding(this, Building_Stargate.ADDITION_DISTANCE);
+                Thing foundThing = Enhanced_Development.Utilities.Utilities.FindItemThingsNearBuilding(this, Building_Stargate.ADDITION_DISTANCE, this.Map);
 
                 if (foundThing != null)
                 {
@@ -416,7 +416,7 @@ namespace Enhanced_Development.Stargate
                 }
 
                 // Tell the MapDrawer that here is something thats changed
-                Find.MapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
+                Find.VisibleMap.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
             }
             else
             {
@@ -450,7 +450,7 @@ namespace Enhanced_Development.Stargate
                 }
 
                 // Tell the MapDrawer that here is something thats changed
-                Find.MapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
+                Find.VisibleMap.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
             }
             else
             {
@@ -474,7 +474,7 @@ namespace Enhanced_Development.Stargate
                     this.listOfBufferThings.Clear();
 
                     // Tell the MapDrawer that here is something thats changed
-                    Find.MapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
+                    Find.VisibleMap.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
 
                     this.currentCapacitorCharge -= this.requiredCapacitorCharge;
                 }
@@ -508,13 +508,13 @@ namespace Enhanced_Development.Stargate
 
                     currentThing.SetFactionDirect(RimWorld.Faction.OfPlayer);
 
-                    GenPlace.TryPlaceThing(currentThing, this.Position + new IntVec3(0, 0, -2), ThingPlaceMode.Near);
+                    GenPlace.TryPlaceThing(currentThing, this.Position + new IntVec3(0, 0, -2), this.Map, ThingPlaceMode.Near);
                 }
                 //Log.Message("End of Placing");
                 inboundBuffer.Clear();
 
                 // Tell the MapDrawer that here is something thats changed
-                Find.MapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
+                Find.VisibleMap.mapDrawer.MapMeshDirty(Position, MapMeshFlag.Things, true, false);
 
                 this.MoveToBackup();
 

--- a/Source/ED-Stargate/Utilities/FindingThings.cs
+++ b/Source/ED-Stargate/Utilities/FindingThings.cs
@@ -15,7 +15,7 @@ namespace Enhanced_Development.Utilities
             //IEnumerable<Pawn> pawns = Find.ListerPawns.FreeColonists;
             //IEnumerable<Pawn> pawns = Find.ListerPawns.AllPawns.Where(item => item.IsColonistPlayerControlled || item.IsColonistPlayerControlled);
 
-            IEnumerable<Pawn> pawns = Find.MapPawns.PawnsInFaction(Faction.OfPlayer);
+            IEnumerable<Pawn> pawns = Find.VisibleMap.mapPawns.PawnsInFaction(Faction.OfPlayer);
 
             IEnumerable<Pawn> closePawns;
 
@@ -38,7 +38,7 @@ namespace Enhanced_Development.Utilities
             {
                 Thing thingAmmo = (Thing)null;
                 Thing thingContainer = (Thing)null;
-                foreach (Thing tempThing in Find.ThingGrid.ThingsAt(sq))
+                foreach (Thing tempThing in Find.VisibleMap.thingGrid.ThingsAt(sq))
                 {
                     //if (tempThing is ThingWithComponents)
                     //{
@@ -64,9 +64,9 @@ namespace Enhanced_Development.Utilities
             return (Thing)null;
         }
 
-        static public Thing FindItemThingsNearBuilding(Thing centerBuilding, int radius)
+        static public Thing FindItemThingsNearBuilding(Thing centerBuilding, int radius, Map map)
         {
-            IEnumerable<Thing> closeThings = GenRadial.RadialDistinctThingsAround(centerBuilding.Position, radius, true);
+            IEnumerable<Thing> closeThings = GenRadial.RadialDistinctThingsAround(centerBuilding.Position, map, radius, true);
 
             foreach (Thing tempThing in closeThings)
             {


### PR DESCRIPTION
Hey @jaxxa!!

Your mods inspired me *so* much in the mid-2010s. In fact, Stargate, LaserDrill, 24H Plants and more were the main reasons I played Rimworld!

When you didn't update ED-Stargate past A14, I got stuck. So much of my internal story play revolved around the same basic people traveling from map to map that I chose to get stuck on A14 until, well, A17 and then I gave up on Rimworld completely. Must have been early 2017.

Well guess what!!

I taught myself C# (I learned *so* much!) and ported your amazing ED-Stargate to A15 and A16!! And I'm going to port it all the way up to the current version, or at least that's the plan!

Here is the pull request!

In [my fork](https://github.com/hopeseekr-contribs/ED-Stargate), I've also completely rewritten what happens when an Offworld Stargate is activated!!

It sends out this *huge* psionic burst, that I'm going to eventually create my own mod for (psionic EMP burst): Every non-insectoid animal lifeform on the map, except psychically insensitives, will likely suffer being knocked out for a few hours (anesthetic) 85% chance, and/or have a heart attack (50% chance). When the team comes through the newly-built offworld gate, they'll have their hands full healing the sick and dying!!

Really enriches the story telling, if you ask me ;-) I made the Offworld Stargate require 1 work unit, so a colonist literally has to "build" It. But when they do, BAM! Everyone's on the ground, twitching!

Fixes Issues #1 and #2.